### PR TITLE
Add failing test: strict mode should accept numbers only domains

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: ruby
+arch:
+  - amd64
+  - ppc64le
+  
 rvm:
   - 2.4.7
   - 2.4.10

--- a/spec/email_validator_spec.rb
+++ b/spec/email_validator_spec.rb
@@ -146,7 +146,8 @@ RSpec.describe EmailValidator do
         'john.doe@a2.com',
         'john.doe@2020.a-z.com',
         'john.doe@2020.a2z.com',
-        'john.doe@2020.12345a6789.com'
+        'john.doe@2020.12345a6789.com',
+        'jonh.doe@163.com'
       ]).flatten.each do |email|
         context 'when using defaults' do
           it "'#{email}' should be valid" do


### PR DESCRIPTION
Hi :)

thanks for this gem!

I've noted that emails like `john.doe@163.com` are not considered valid in `:strict` mode. `163.com` is a valid chinese email provider though.

I provided a failing test with this PR.

What do you think about this?