### PR TITLE
Fix: specifying require_fqdn: true in the default (:loose) mode had no effect

### DIFF
--- a/lib/email_validator.rb
+++ b/lib/email_validator.rb
@@ -55,7 +55,7 @@ class EmailValidator < ActiveModel::EachValidator
     protected
 
     def loose_regexp(options = {})
-      return /\A[^\s]+@[^\s]+\z/ if options[:domain].nil?
+      return /\A[^\s]+@[^\s]+\z/ if options[:domain].nil? && !options[:require_fqdn]
       /\A[^\s]+@#{domain_part_pattern(options)}\z/
     end
 

--- a/spec/email_validator_spec.rb
+++ b/spec/email_validator_spec.rb
@@ -764,6 +764,28 @@ RSpec.describe EmailValidator do
       end
     end
 
+    context 'when `require_fqdn` is explicitly enabled' do
+      let(:opts) { { :require_fqdn => true } }
+
+      context 'when given a valid hostname-only email' do
+        let(:email) { 'someuser@somehost' }
+
+        context 'when in `:loose` mode (the default)' do
+          it 'is invalid using EmailValidator.valid?' do
+            expect(described_class).not_to be_valid(email, opts)
+          end
+
+          it 'is invalid using EmailValidator.invalid?' do
+            expect(described_class).to be_invalid(email, opts)
+          end
+
+          it 'does not match the regexp' do
+            expect(!!(email =~ described_class.regexp(opts))).to be(false)
+          end
+        end
+      end
+    end
+
     context 'when `require_fqdn` is explicitly disabled' do
       let(:opts) { { :require_fqdn => false } }
 


### PR DESCRIPTION
… because `loose_regexp` didn't even call `domain_part_pattern` if `options[:domain].nil?`

My workaround for now is to trick it by making `options[:domain]` non-nil:
```ruby
email: { domain: '', require_fqdn: true }
```