### PR TITLE
Remove Check for Double Hyphens

### DIFF
--- a/lib/email_validator.rb
+++ b/lib/email_validator.rb
@@ -94,7 +94,6 @@ class EmailValidator < ActiveModel::EachValidator
 
     def host_label_pattern
       "#{label_is_correct_length}" \
-      "#{label_contains_no_more_than_one_consecutive_hyphen}" \
       "#{alnum}(?:#{alnumhy}{,61}#{alnum})?"
     end
 
@@ -121,10 +120,6 @@ class EmailValidator < ActiveModel::EachValidator
 
     def domain_part_is_correct_length
       '(?=.{1,255}$)'
-    end
-
-    def label_contains_no_more_than_one_consecutive_hyphen
-      '(?!.*?--.*$)'
     end
 
     def atom_char

--- a/spec/email_validator_spec.rb
+++ b/spec/email_validator_spec.rb
@@ -147,7 +147,9 @@ RSpec.describe EmailValidator do
         'john.doe@2020.a-z.com',
         'john.doe@2020.a2z.com',
         'john.doe@2020.12345a6789.com',
-        'jonh.doe@163.com'
+        'jonh.doe@163.com',
+        'test@umläut.com', # non-ASCII
+        'test@xn--umlut-ira.com' # ASCII-compatibale encoding of non-ASCII
       ]).flatten.each do |email|
         context 'when using defaults' do
           it "'#{email}' should be valid" do
@@ -477,7 +479,6 @@ RSpec.describe EmailValidator do
         'host-beginning-with-dot@.example.com',
         'domain-beginning-with-dash@-example.com',
         'domain-ending-with-dash@example-.com',
-        'domain-contains-double-dash@foo--example.com',
         'the-local-part-is-invalid-if-it-is-longer-than-sixty-four-characters@sld.dev',
         "domain-too-long@t#{".#{'o' * 63}" * 5}.long",
         "user@example.com<script>alert('hello')</script>"


### PR DESCRIPTION
I cannot find any standard that says that we cannot have double hyphens in domain names. I don't know where I got that idea. Since it is clearly supposed to be valid in the case of ACE IDNs, I am removing it.